### PR TITLE
Bug Fix: Use D24S8 explicitly in GL3 driver

### DIFF
--- a/src/gl/gl3device.cpp
+++ b/src/gl/gl3device.cpp
@@ -1274,7 +1274,7 @@ setFrameBuffer(Camera *cam)
 				Gl3Raster *oldfb = PLUGINOFFSET(Gl3Raster, natzb->fboMate, nativeRasterOffset);
 				if(oldfb->fbo){
 					bindFramebuffer(oldfb->fbo);
-					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+					glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, 0, 0);
 					bindFramebuffer(natfb->fbo);
 				}
 				oldfb->fboMate = nil;
@@ -1283,15 +1283,15 @@ setFrameBuffer(Camera *cam)
 			natzb->fboMate = fbuf;
 			if(natfb->fbo){
 				if(gl3Caps.gles)
-					glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, natzb->texid);
+					glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, natzb->texid);
 				else
-					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, natzb->texid, 0);
+					glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, natzb->texid, 0);
 			}
 		}
 	}else{
 		// remove z-buffer
 		if(natfb->fboMate && natfb->fbo)
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+			glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, 0, 0);
 		natfb->fboMate = nil;
 	}
 }

--- a/src/gl/gl3raster.cpp
+++ b/src/gl/gl3raster.cpp
@@ -233,12 +233,12 @@ rasterCreateZbuffer(Raster *raster)
 		// have to use RBO on GLES!!
 		glGenRenderbuffers(1, &natras->texid);
 		glBindRenderbuffer(GL_RENDERBUFFER, natras->texid);
-		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, raster->width, raster->height);
+		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, raster->width, raster->height);
 	}else{
 		// TODO: set/check width, height, depth, format?
-		natras->internalFormat = GL_DEPTH_COMPONENT;
-		natras->format = GL_DEPTH_COMPONENT;
-		natras->type = GL_UNSIGNED_BYTE;
+		natras->internalFormat = GL_DEPTH_STENCIL;
+		natras->format = GL_DEPTH_STENCIL;
+		natras->type = GL_UNSIGNED_INT_24_8;
 
 		natras->autogenMipmap = 0;
 
@@ -735,7 +735,7 @@ destroyNativeRaster(void *object, int32 offset, int32)
 			Gl3Raster *oldfb = GETGL3RASTEREXT(natras->fboMate);
 			if(oldfb->fbo){
 				bindFramebuffer(oldfb->fbo);
-				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
 			}
 			oldfb->fboMate = nil;
 		}


### PR DESCRIPTION
I recently noticed stencil buffers weren't working when using render targets (rwRASTERTYPECAMERATEXTURE) in OpenGL. After some poking around in RenderDoc I noticed the texture format was incorrect and made the following patch. I've also verified that in RW37 the d3d9 plugin [requests a stencil when available](https://github.com/GTAmodding/rw37/blob/master/src/driver/d3d9/d3d9raster.c#L3564).

Unfortunately I'm not sure how we should query if a particular format is supported on OpenGL; so I'll defer to the maintainers for guidance. 🙂  