### PR TITLE
D3DDevice recreateVidmemRasters and IDirect3DDevice::CreateTexture undefined behavior

### DIFF
--- a/src/d3d/d3ddevice.cpp
+++ b/src/d3d/d3ddevice.cpp
@@ -1129,7 +1129,7 @@ recreateVidmemRasters(void)
 		switch(raster->type){
 		case Raster::CAMERATEXTURE: {
 			int32 levels = Raster::calculateNumLevels(raster->width, raster->height);
-			IDirect3DTexture9 *tex;
+			IDirect3DTexture9 *tex = nil;
 			d3ddevice->CreateTexture(raster->width, raster->height,
 						raster->format & Raster::MIPMAP ? levels : 1,
 						D3DUSAGE_RENDERTARGET,


### PR DESCRIPTION
`natras->texture` contains an invalid pointer (usually whatever was on the stack at the time) if the call to `IDirect3DDevice::CreateTexture` fails. By ensuring that the value of `tex` is defaulted to null correct behavior is restored.

It is possible to simulate a crash case if you try to alt-tab or place breakpoints during DirectX initialization causing loss of exclusive full screen mode failing the API calls.