### PR TITLE
Fix for high-dpi resolution when using OpenGL

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -216,8 +216,10 @@ cameraSync(ObjectWithFrame *obj)
 	inv.at.x = -inv.at.x;
 	inv.pos.x = -inv.pos.x;
 
-	float32 xscl = 1.0f/(2.0f*cam->viewWindow.x);
-	float32 yscl = 1.0f/(2.0f*cam->viewWindow.y);
+	V2d dpiScale = engine->device.dpiScale(cam->frameBuffer->width, cam->frameBuffer->height);
+
+	float32 xscl = 1.0f/(2.0f*cam->viewWindow.x*dpiScale.x);
+	float32 yscl = 1.0f/(2.0f*cam->viewWindow.y*dpiScale.y);
 
 	proj.flags = 0;
 	proj.right.x = xscl;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -559,6 +559,7 @@ Device renderdevice = {
 	null::im3DRenderPrimitive,
 	null::im3DRenderIndexedPrimitive,
 	null::im3DEnd,
+	null::dpiScale,
 	null::deviceSystem
 };
 

--- a/src/gl/gl3device.cpp
+++ b/src/gl/gl3device.cpp
@@ -1388,7 +1388,10 @@ static V2d dpiScale(float x, float y)
 	int w = 0;
         int h = 0;
         glfwGetFramebufferSize(glGlobals.window, &w, &h);
-	v.set(w / x, h / y);
+	if (w && h)
+		v.set(w / x, h / y);
+	else
+		v.set(1,1);
 	return v;
 }
 
@@ -1409,8 +1412,12 @@ rasterRenderFast(Raster *raster, int32 x, int32 y)
 		case Raster::CAMERA:
 			setActiveTexture(0);
 			glBindTexture(GL_TEXTURE_2D, natdst->texid);
-			glCopyTexSubImage2D(GL_TEXTURE_2D, 0, x, (dst->height-src->height)-y,
-				src->width/dpiScale.x, src->height/dpiScale.y, src->width, src->height);
+			if(dpiScale.x != 1 || dpiScale.y != 1)
+				glCopyTexSubImage2D(GL_TEXTURE_2D, 0, x, (dst->height-src->height)-y,
+					src->width/dpiScale.x, src->height/dpiScale.y, src->width, src->height);
+			else
+				glCopyTexSubImage2D(GL_TEXTURE_2D, 0, x, (dst->height-src->height)-y,
+					0, 0, src->width, src->height);
 			glBindTexture(GL_TEXTURE_2D, boundTexture[0]);
 			return 1;
 		}

--- a/src/rwengine.h
+++ b/src/rwengine.h
@@ -66,6 +66,7 @@ struct Device
 	void (*im3DRenderIndexedPrimitive)(PrimitiveType primType, void *indices, int32 numIndices);
 	void (*im3DEnd)(void);
 
+	V2d (*dpiScale)(float x, float y);
 	DeviceSystem *system;
 };
 
@@ -254,6 +255,13 @@ namespace null {
 	void im3DRenderPrimitive(PrimitiveType primType);
 	void im3DRenderIndexedPrimitive(PrimitiveType primType, void *indices, int32 numIndices);
 	void im3DEnd(void);
+
+	inline V2d dpiScale(float,float)
+	{
+		V2d s;
+		s.set(1.f, 1.f);
+		return s;
+	}
 
 	int deviceSystem(DeviceReq req, void *arg0, int32 n);
 


### PR DESCRIPTION
This is a fix for https://github.com/aap/librw/issues/63

Other device apis should be checked for regressions. There is an added inline for the null device that returns a scaling factor of 1,1 but unsure if this alone is enough to satisfy other apis.