### PR TITLE
GL: Fix MSAA off mode

### DIFF
--- a/src/gl/gl3device.cpp
+++ b/src/gl/gl3device.cpp
@@ -1723,7 +1723,11 @@ startGLFW(void)
 	glfwWindowHint(GLFW_GREEN_BITS, mode->mode.greenBits);
 	glfwWindowHint(GLFW_BLUE_BITS, mode->mode.blueBits);
 	glfwWindowHint(GLFW_REFRESH_RATE, mode->mode.refreshRate);
-	glfwWindowHint(GLFW_SAMPLES, glGlobals.numSamples);
+	
+	// GLX will round up to 2x or 4x if you ask for multisampling on with 1 sample
+	// So only apply the SAMPLES hint if we actually want multisampling
+	if (glGlobals.numSamples > 1)
+		glfwWindowHint(GLFW_SAMPLES, glGlobals.numSamples);
 
 	int i;
 	for(i = 0; profiles[i].gl; i++){


### PR DESCRIPTION
GLX will round up to it's lowest MSAA mode (2x or 4x) if you ask for multisampling on with 1 sample.

If you actually want MSAA off because you actually like those ugly jaggies, you need to either not apply the hint, or apply a hint of zero. 