### PR TITLE
examples: fix imguitest

### DIFF
--- a/tools/imguitest/main.cpp
+++ b/tools/imguitest/main.cpp
@@ -109,13 +109,12 @@ Draw(float timeDelta)
 
 
 	ImGui::EndFrame();
-
 	ImGui::Render();
+
+	ImGui_ImplRW_RenderDrawLists(ImGui::GetDrawData());
 
 	Scene.camera->endUpdate();
 	Scene.camera->showRaster(0);
-
-	ImGui_ImplRW_RenderDrawLists(ImGui::GetDrawData());
 }
 
 


### PR DESCRIPTION
#86 inserted the `ImGui_ImplRW_RenderDrawLists` call in the wrong place.
The other examples are ok.