### PR TITLE
cmake: build tools and install librw by default, only when main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(librw_MAINPROJECT ON)
+if(DEFINED PROJECT_NAME)
+    set(librw_MAINPROJECT OFF)
+endif()
+
 cmake_minimum_required(VERSION 3.8)
 project(librw
     VERSION 0.0.1
@@ -54,8 +59,8 @@ endif()
 
 include(CMakeDependentOption)
 
-option(LIBRW_TOOLS "Build librw tools" ON)
-option(LIBRW_INSTALL "Install librw files" OFF)
+option(LIBRW_TOOLS "Build librw tools" ${librw_MAINPROJECT})
+option(LIBRW_INSTALL "Install librw files" ${librw_MAINPROJECT})
 cmake_dependent_option(LIBRW_EXAMPLES "Build librw examples" ON "LIBRW_TOOLS;NOT LIBRW_PLATFORM_NULL" OFF)
 
 if(LIBRW_INSTALL)


### PR DESCRIPTION
@withmorten

Something like this?

`LIBRW_TOOLS` and `LIBRW_INSTALL` are set to `ON` only when `librw` is not included as a subproject.