### PR TITLE
Fix double-free materials

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -727,6 +727,7 @@ MaterialList::deinit(void)
 		for(int32 i = 0; i < this->numMaterials; i++)
 			this->materials[i]->destroy();
 		rwFree(this->materials);
+		this->materials = nil;
 	}
 }
 


### PR DESCRIPTION
Fix crash with double-free materials.

To reproduce, try to read invalid geometry in release build